### PR TITLE
Swift layout simplification

### DIFF
--- a/CustomCollectionLayout/CustomCollectionViewLayout.swift
+++ b/CustomCollectionLayout/CustomCollectionViewLayout.swift
@@ -11,8 +11,8 @@ import UIKit
 class CustomCollectionViewLayout: UICollectionViewLayout {
 
     let numberOfColumns = 8
-    var itemAttributes : NSMutableArray!
-    var itemsSize : NSMutableArray!
+    var itemAttributes = [[UICollectionViewLayoutAttributes]]()
+    var itemsSize = [CGSize]()
     var contentSize : CGSize!
     
     override func prepareLayout() {
@@ -20,7 +20,7 @@ class CustomCollectionViewLayout: UICollectionViewLayout {
             return
         }
         
-        if (self.itemAttributes != nil && self.itemAttributes.count > 0) {
+        if (self.itemAttributes.count > 0) {
             for section in 0..<self.collectionView!.numberOfSections() {
                 let numberOfItems = self.collectionView!.numberOfItemsInSection(section)
                 for index in 0..<numberOfItems {
@@ -45,7 +45,7 @@ class CustomCollectionViewLayout: UICollectionViewLayout {
             return
         }
         
-        if (self.itemsSize == nil || self.itemsSize.count != numberOfColumns) {
+        if (self.itemsSize.count != numberOfColumns) {
             self.calculateItemsSize()
         }
         
@@ -59,7 +59,7 @@ class CustomCollectionViewLayout: UICollectionViewLayout {
             var sectionAttributes = [UICollectionViewLayoutAttributes]()
             
             for index in 0..<numberOfColumns {
-                let itemSize = self.itemsSize[index].CGSizeValue()
+                let itemSize = self.itemsSize[index]
                 let indexPath = NSIndexPath(forItem: index, inSection: section)
                 let attributes = UICollectionViewLayoutAttributes(forCellWithIndexPath: indexPath)
                 attributes.frame = CGRectIntegral(CGRectMake(xOffset, yOffset, itemSize.width, itemSize.height))
@@ -96,13 +96,11 @@ class CustomCollectionViewLayout: UICollectionViewLayout {
                     yOffset += itemSize.height
                 }
             }
-            if (self.itemAttributes == nil) {
-                self.itemAttributes = NSMutableArray(capacity: self.collectionView!.numberOfSections())
-            }
-            self.itemAttributes .addObject(sectionAttributes)
+
+            self.itemAttributes.append(sectionAttributes)
         }
-        
-        let attributes = self.itemAttributes.lastObject?.lastObject as! UICollectionViewLayoutAttributes
+      
+        let attributes = self.itemAttributes.last!.last!
         contentHeight = attributes.frame.origin.y + attributes.frame.size.height
         self.contentSize = CGSizeMake(contentWidth, contentHeight)
     }
@@ -116,26 +114,18 @@ class CustomCollectionViewLayout: UICollectionViewLayout {
     }
     
     override func layoutAttributesForElementsInRect(rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
-        var attributes = [UICollectionViewLayoutAttributes]()
-        if self.itemAttributes != nil {
-            for section in self.itemAttributes {
-                
-                let filteredArray  =  section.filteredArrayUsingPredicate(
-                    
-                    NSPredicate(block: { (evaluatedObject, bindings) -> Bool in
-                        return CGRectIntersectsRect(rect, evaluatedObject.frame)
-                    })
-                    ) as! [UICollectionViewLayoutAttributes]
-                
-                
-                attributes.appendContentsOf(filteredArray)
-                
-            }
+      var attributes = [UICollectionViewLayoutAttributes]()
+      
+      for section in self.itemAttributes {
+        let filteredArray = section.filter { obj -> Bool in
+          return CGRectIntersectsRect(rect, obj.frame)
         }
-        
-        return attributes
+        attributes.appendContentsOf(filteredArray)
+      }
+      
+      return attributes
     }
-    
+  
     override func shouldInvalidateLayoutForBoundsChange(newBounds: CGRect) -> Bool {
         return true
     }
@@ -167,9 +157,8 @@ class CustomCollectionViewLayout: UICollectionViewLayout {
     }
     
     func calculateItemsSize() {
-        self.itemsSize = NSMutableArray(capacity: numberOfColumns)
         for index in 0..<numberOfColumns {
-            self.itemsSize.addObject(NSValue(CGSize: self.sizeForItemWithColumnIndex(index)))
+            self.itemsSize.append(self.sizeForItemWithColumnIndex(index))
         }
     }
 }

--- a/CustomCollectionLayout/CustomCollectionViewLayout.swift
+++ b/CustomCollectionLayout/CustomCollectionViewLayout.swift
@@ -10,19 +10,19 @@ import UIKit
 
 class CustomCollectionViewLayout: UICollectionViewLayout {
 
-    let numberOfColumns = 8
-    var itemAttributes = [[UICollectionViewLayoutAttributes]]()
-    var itemsSize = [CGSize]()
-    var contentSize : CGSize!
+    private let numberOfColumns = 8
+    private var itemAttributes = [[UICollectionViewLayoutAttributes]]()
+    private var itemsSize = [CGSize]()
+    private var contentSize : CGSize!
     
     override func prepareLayout() {
-        if self.collectionView?.numberOfSections() == 0 {
+        if collectionView!.numberOfSections() == 0 {
             return
         }
         
-        if (self.itemAttributes.count > 0) {
-            for section in 0..<self.collectionView!.numberOfSections() {
-                let numberOfItems = self.collectionView!.numberOfItemsInSection(section)
+        if (itemAttributes.count > 0) {
+            for section in 0..<collectionView!.numberOfSections() {
+                let numberOfItems = collectionView!.numberOfItemsInSection(section)
                 for index in 0..<numberOfItems {
                     if section != 0 && index != 0 {
                         continue
@@ -45,8 +45,8 @@ class CustomCollectionViewLayout: UICollectionViewLayout {
             return
         }
         
-        if (self.itemsSize.count != numberOfColumns) {
-            self.calculateItemsSize()
+        if itemsSize.count != numberOfColumns {
+            calculateItemsSize()
         }
         
         var column = 0
@@ -59,7 +59,7 @@ class CustomCollectionViewLayout: UICollectionViewLayout {
             var sectionAttributes = [UICollectionViewLayoutAttributes]()
             
             for index in 0..<numberOfColumns {
-                let itemSize = self.itemsSize[index]
+                let itemSize = itemsSize[index]
                 let indexPath = NSIndexPath(forItem: index, inSection: section)
                 let attributes = UICollectionViewLayoutAttributes(forCellWithIndexPath: indexPath)
                 attributes.frame = CGRectIntegral(CGRectMake(xOffset, yOffset, itemSize.width, itemSize.height))
@@ -97,26 +97,26 @@ class CustomCollectionViewLayout: UICollectionViewLayout {
                 }
             }
 
-            self.itemAttributes.append(sectionAttributes)
+            itemAttributes.append(sectionAttributes)
         }
       
-        let attributes = self.itemAttributes.last!.last!
+        let attributes = itemAttributes.last!.last!
         contentHeight = attributes.frame.origin.y + attributes.frame.size.height
-        self.contentSize = CGSizeMake(contentWidth, contentHeight)
+        contentSize = CGSizeMake(contentWidth, contentHeight)
     }
     
     override func collectionViewContentSize() -> CGSize {
-        return self.contentSize
+        return contentSize
     }
     
     override func layoutAttributesForItemAtIndexPath(indexPath: NSIndexPath) -> UICollectionViewLayoutAttributes! {
-        return self.itemAttributes[indexPath.section][indexPath.row] as! UICollectionViewLayoutAttributes
+        return itemAttributes[indexPath.section][indexPath.row] as! UICollectionViewLayoutAttributes
     }
     
     override func layoutAttributesForElementsInRect(rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
       var attributes = [UICollectionViewLayoutAttributes]()
       
-      for section in self.itemAttributes {
+      for section in itemAttributes {
         let filteredArray = section.filter { obj -> Bool in
           return CGRectIntersectsRect(rect, obj.frame)
         }
@@ -131,7 +131,7 @@ class CustomCollectionViewLayout: UICollectionViewLayout {
     }
     
     func sizeForItemWithColumnIndex(columnIndex: Int) -> CGSize {
-        var text : String = ""
+        var text = ""
         switch (columnIndex) {
         case 0:
             text = "Col 0"
@@ -151,14 +151,14 @@ class CustomCollectionViewLayout: UICollectionViewLayout {
             text = "Col 7"
         }
         
-        let size : CGSize = (text as NSString).sizeWithAttributes([NSFontAttributeName: UIFont.systemFontOfSize(17.0)])
-        let width : CGFloat = size.width + 25
+        let size = (text as NSString).sizeWithAttributes([NSFontAttributeName: UIFont.systemFontOfSize(17.0)])
+        let width = size.width + 25
         return CGSizeMake(width, 30)
     }
     
     func calculateItemsSize() {
         for index in 0..<numberOfColumns {
-            self.itemsSize.append(self.sizeForItemWithColumnIndex(index))
+            itemsSize.append(sizeForItemWithColumnIndex(index))
         }
     }
 }

--- a/CustomCollectionLayout/CustomCollectionViewLayout.swift
+++ b/CustomCollectionLayout/CustomCollectionViewLayout.swift
@@ -30,15 +30,15 @@ class CustomCollectionViewLayout: UICollectionViewLayout {
                     
                     let attributes = layoutAttributesForItemAtIndexPath(NSIndexPath(forItem: index, inSection: section))
                     if section == 0 {
-                        var frame = attributes.frame
+                        var frame = attributes!.frame
                         frame.origin.y = collectionView!.contentOffset.y
-                        attributes.frame = frame
+                        attributes!.frame = frame
                     }
                     
                     if index == 0 {
-                        var frame = attributes.frame
+                        var frame = attributes!.frame
                         frame.origin.x = collectionView!.contentOffset.x
-                        attributes.frame = frame
+                        attributes!.frame = frame
                     }
                 }
             }
@@ -109,8 +109,8 @@ class CustomCollectionViewLayout: UICollectionViewLayout {
         return contentSize
     }
     
-    override func layoutAttributesForItemAtIndexPath(indexPath: NSIndexPath) -> UICollectionViewLayoutAttributes! {
-        return itemAttributes[indexPath.section][indexPath.row] as! UICollectionViewLayoutAttributes
+    override func layoutAttributesForItemAtIndexPath(indexPath: NSIndexPath) -> UICollectionViewLayoutAttributes? {
+        return itemAttributes[indexPath.section][indexPath.row]
     }
     
     override func layoutAttributesForElementsInRect(rect: CGRect) -> [UICollectionViewLayoutAttributes]? {

--- a/CustomCollectionLayout/CustomCollectionViewLayout.swift
+++ b/CustomCollectionLayout/CustomCollectionViewLayout.swift
@@ -22,13 +22,13 @@ class CustomCollectionViewLayout: UICollectionViewLayout {
         
         if (self.itemAttributes != nil && self.itemAttributes.count > 0) {
             for section in 0..<self.collectionView!.numberOfSections() {
-                var numberOfItems : Int = self.collectionView!.numberOfItemsInSection(section)
+                let numberOfItems = self.collectionView!.numberOfItemsInSection(section)
                 for index in 0..<numberOfItems {
                     if section != 0 && index != 0 {
                         continue
                     }
                     
-                    var attributes : UICollectionViewLayoutAttributes = self.layoutAttributesForItemAtIndexPath(NSIndexPath(forItem: index, inSection: section))
+                    let attributes = self.layoutAttributesForItemAtIndexPath(NSIndexPath(forItem: index, inSection: section))
                     if section == 0 {
                         var frame = attributes.frame
                         frame.origin.y = self.collectionView!.contentOffset.y
@@ -56,12 +56,12 @@ class CustomCollectionViewLayout: UICollectionViewLayout {
         var contentHeight : CGFloat = 0
         
         for section in 0..<self.collectionView!.numberOfSections() {
-            var sectionAttributes = NSMutableArray()
+            var sectionAttributes = [UICollectionViewLayoutAttributes]()
             
             for index in 0..<numberOfColumns {
-                var itemSize = self.itemsSize[index].CGSizeValue()
-                var indexPath = NSIndexPath(forItem: index, inSection: section)
-                var attributes = UICollectionViewLayoutAttributes(forCellWithIndexPath: indexPath)
+                let itemSize = self.itemsSize[index].CGSizeValue()
+                let indexPath = NSIndexPath(forItem: index, inSection: section)
+                let attributes = UICollectionViewLayoutAttributes(forCellWithIndexPath: indexPath)
                 attributes.frame = CGRectIntegral(CGRectMake(xOffset, yOffset, itemSize.width, itemSize.height))
                 
                 if section == 0 && index == 0 {
@@ -81,10 +81,10 @@ class CustomCollectionViewLayout: UICollectionViewLayout {
                     attributes.frame = frame
                 }
                 
-                sectionAttributes.addObject(attributes)
+                sectionAttributes.append(attributes)
                 
                 xOffset += itemSize.width
-                column++
+                column += 1
                 
                 if column == numberOfColumns {
                     if xOffset > contentWidth {
@@ -102,7 +102,7 @@ class CustomCollectionViewLayout: UICollectionViewLayout {
             self.itemAttributes .addObject(sectionAttributes)
         }
         
-        var attributes : UICollectionViewLayoutAttributes = self.itemAttributes.lastObject?.lastObject as! UICollectionViewLayoutAttributes
+        let attributes = self.itemAttributes.lastObject?.lastObject as! UICollectionViewLayoutAttributes
         contentHeight = attributes.frame.origin.y + attributes.frame.size.height
         self.contentSize = CGSizeMake(contentWidth, contentHeight)
     }

--- a/CustomCollectionLayout/CustomCollectionViewLayout.swift
+++ b/CustomCollectionLayout/CustomCollectionViewLayout.swift
@@ -28,16 +28,16 @@ class CustomCollectionViewLayout: UICollectionViewLayout {
                         continue
                     }
                     
-                    let attributes = self.layoutAttributesForItemAtIndexPath(NSIndexPath(forItem: index, inSection: section))
+                    let attributes = layoutAttributesForItemAtIndexPath(NSIndexPath(forItem: index, inSection: section))
                     if section == 0 {
                         var frame = attributes.frame
-                        frame.origin.y = self.collectionView!.contentOffset.y
+                        frame.origin.y = collectionView!.contentOffset.y
                         attributes.frame = frame
                     }
                     
                     if index == 0 {
                         var frame = attributes.frame
-                        frame.origin.x = self.collectionView!.contentOffset.x
+                        frame.origin.x = collectionView!.contentOffset.x
                         attributes.frame = frame
                     }
                 }
@@ -55,7 +55,7 @@ class CustomCollectionViewLayout: UICollectionViewLayout {
         var contentWidth : CGFloat = 0
         var contentHeight : CGFloat = 0
         
-        for section in 0..<self.collectionView!.numberOfSections() {
+        for section in 0..<collectionView!.numberOfSections() {
             var sectionAttributes = [UICollectionViewLayoutAttributes]()
             
             for index in 0..<numberOfColumns {
@@ -72,12 +72,12 @@ class CustomCollectionViewLayout: UICollectionViewLayout {
                 
                 if section == 0 {
                     var frame = attributes.frame
-                    frame.origin.y = self.collectionView!.contentOffset.y
+                    frame.origin.y = collectionView!.contentOffset.y
                     attributes.frame = frame
                 }
                 if index == 0 {
                     var frame = attributes.frame
-                    frame.origin.x = self.collectionView!.contentOffset.x
+                    frame.origin.x = collectionView!.contentOffset.x
                     attributes.frame = frame
                 }
                 

--- a/CustomCollectionLayout/CustomCollectionViewLayout.swift
+++ b/CustomCollectionLayout/CustomCollectionViewLayout.swift
@@ -131,26 +131,7 @@ class CustomCollectionViewLayout: UICollectionViewLayout {
     }
     
     func sizeForItemWithColumnIndex(columnIndex: Int) -> CGSize {
-        var text = ""
-        switch (columnIndex) {
-        case 0:
-            text = "Col 0"
-        case 1:
-            text = "Col 1"
-        case 2:
-            text = "Col 2"
-        case 3:
-            text = "Col 3"
-        case 4:
-            text = "Col 4"
-        case 5:
-            text = "Col 5"
-        case 6:
-            text = "Col 6"
-        default:
-            text = "Col 7"
-        }
-        
+        let text = "Col \(columnIndex)"
         let size = (text as NSString).sizeWithAttributes([NSFontAttributeName: UIFont.systemFontOfSize(17.0)])
         let width = size.width + 25
         return CGSizeMake(width, 30)

--- a/CustomCollectionLayout/CustomCollectionViewLayout.swift
+++ b/CustomCollectionLayout/CustomCollectionViewLayout.swift
@@ -13,7 +13,7 @@ class CustomCollectionViewLayout: UICollectionViewLayout {
     private let numberOfColumns = 8
     private var itemAttributes = [[UICollectionViewLayoutAttributes]]()
     private var itemsSize = [CGSize]()
-    private var contentSize : CGSize!
+    private var contentSize = CGSizeZero
     
     override func prepareLayout() {
         if collectionView!.numberOfSections() == 0 {


### PR DESCRIPTION
# Description

The purpose of this PR is to simplify the code without changing behavior or coding style.

I made this file more "Swifty". I noticed several Objective-C idioms such as NSMutableArray and calls to `self` when referring to an property.

Additionally, I simplified some blocks of code without changing the behavior, such as `sizeForItemWithColumnIndex`.

In any case, this project is a great idea. Good work!
